### PR TITLE
Improvements

### DIFF
--- a/C#/TollCalculator.cs
+++ b/C#/TollCalculator.cs
@@ -4,52 +4,49 @@ using TollFeeCalculator;
 
 public class TollCalculator
 {
+    private IHolidayService HolidayService { get; }
 
-    /**
-     * Calculate the total toll fee for one day
-     *
-     * @param vehicle - the vehicle
-     * @param dates   - date and time of all passes on one day
-     * @return - the total toll fee for that day
-     */
-
-    public int GetTollFee(Vehicle vehicle, DateTime[] dates)
+    public TollCalculator(IHolidayService holidayService)
     {
-        DateTime intervalStart = dates[0];
-        int totalFee = 0;
-        foreach (DateTime date in dates)
-        {
-            int nextFee = GetTollFee(date, vehicle);
-            int tempFee = GetTollFee(intervalStart, vehicle);
-
-            long diffInMillies = date.Millisecond - intervalStart.Millisecond;
-            long minutes = diffInMillies/1000/60;
-
-            if (minutes <= 60)
-            {
-                if (totalFee > 0) totalFee -= tempFee;
-                if (nextFee >= tempFee) tempFee = nextFee;
-                totalFee += tempFee;
-            }
-            else
-            {
-                totalFee += nextFee;
-            }
-        }
-        if (totalFee > 60) totalFee = 60;
-        return totalFee;
+        this.HolidayService = holidayService ?? throw new ArgumentNullException(nameof(holidayService));
     }
 
-    private bool IsTollFreeVehicle(Vehicle vehicle)
+    /// <summary>
+    ///     Calculates the total toll fee for one day
+    /// </summary>
+    /// <param name="vehicle">The vehicle</param>
+    /// <param name="dates">Date and time of all passes on one day</param>
+    /// <returns>The total toll fee for that day</returns>
+    public int GetTollFee(Vehicle vehicle, DateTime[] dates)
     {
-        if (vehicle == null) return false;
-        String vehicleType = vehicle.GetVehicleType();
-        return vehicleType.Equals(TollFreeVehicles.Motorbike.ToString()) ||
-               vehicleType.Equals(TollFreeVehicles.Tractor.ToString()) ||
-               vehicleType.Equals(TollFreeVehicles.Emergency.ToString()) ||
-               vehicleType.Equals(TollFreeVehicles.Diplomat.ToString()) ||
-               vehicleType.Equals(TollFreeVehicles.Foreign.ToString()) ||
-               vehicleType.Equals(TollFreeVehicles.Military.ToString());
+        if (dates is null || !dates.Any())
+            return 0;
+
+        dates = Array.Sort(dates); // In case they were not sorted already
+
+        DateTime intervalStart = dates[0];
+        int totalFee = 0;
+        int intervalFee = 0;
+
+        foreach (DateTime date in dates)
+        {
+            int fee = GetTollFee(date, vehicle);
+
+            if (date > intervalStart.AddHours(1)) // New interval
+            {
+                intervalStart = date;
+                intervalFee = 0;
+            }
+
+            totalFee += Math.Max(0, fee - intervalFee); // Charge only what has not yet been charged this hour
+
+            if (totalFee >= 60)
+                return 60;
+
+            intervalFee = Math.Max(fee, intervalFee);
+        }
+
+        return totalFee;
     }
 
     public int GetTollFee(DateTime date, Vehicle vehicle)
@@ -59,40 +56,35 @@ public class TollCalculator
         int hour = date.Hour;
         int minute = date.Minute;
 
-        if (hour == 6 && minute >= 0 && minute <= 29) return 8;
-        else if (hour == 6 && minute >= 30 && minute <= 59) return 13;
-        else if (hour == 7 && minute >= 0 && minute <= 59) return 18;
-        else if (hour == 8 && minute >= 0 && minute <= 29) return 13;
-        else if (hour >= 8 && hour <= 14 && minute >= 30 && minute <= 59) return 8;
-        else if (hour == 15 && minute >= 0 && minute <= 29) return 13;
-        else if (hour == 15 && minute >= 0 || hour == 16 && minute <= 59) return 18;
-        else if (hour == 17 && minute >= 0 && minute <= 59) return 13;
-        else if (hour == 18 && minute >= 0 && minute <= 29) return 8;
-        else return 0;
+        if (hour <= 5) return 0;
+        if (hour == 6 && minute <= 29) return 8;
+        if (hour == 6) return 13;
+        if (hour == 7) return 18;
+        if (hour == 8 && minute <= 29) return 13;
+        if (hour <= 14) return minute <= 29 ? 0 : 8;
+        if (hour == 15 && minute <= 29) return 13;
+        if (hour <= 16) return 18;
+        if (hour == 17) return 13;
+        if (hour == 18 && minute <= 29) return 8;
+        return 0;
     }
 
-    private Boolean IsTollFreeDate(DateTime date)
+    private bool IsTollFreeVehicle(Vehicle vehicle)
     {
-        int year = date.Year;
-        int month = date.Month;
-        int day = date.Day;
+        if (vehicle == null) return false;
+        var vehicleType = vehicle.GetVehicleType();
+        return TollFreeVehicles.TryParse(vehicleType, out _);
+    }
 
+    private bool IsTollFreeDate(DateTime date)
+    {
         if (date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday) return true;
 
-        if (year == 2013)
-        {
-            if (month == 1 && day == 1 ||
-                month == 3 && (day == 28 || day == 29) ||
-                month == 4 && (day == 1 || day == 30) ||
-                month == 5 && (day == 1 || day == 8 || day == 9) ||
-                month == 6 && (day == 5 || day == 6 || day == 21) ||
-                month == 7 ||
-                month == 11 && day == 1 ||
-                month == 12 && (day == 24 || day == 25 || day == 26 || day == 31))
-            {
-                return true;
-            }
-        }
+        var holidays = this.HolidayService.GetHolidays(date.Year);
+
+        if (holidays.Any(holiday => holiday.Date == date.Date))
+            return true;
+
         return false;
     }
 
@@ -104,5 +96,10 @@ public class TollCalculator
         Diplomat = 3,
         Foreign = 4,
         Military = 5
+    }
+
+    public interface IHolidayService
+    {
+        public List<DateTime> GetHolidays(int year); // Maybe get from an API
     }
 }


### PR DESCRIPTION
There was a bug in GetTollFee(Vehicle vehicle, DateTime[] dates), where the intervalStart was never reset. So all passes that occurred more than one hour after the first pass would be charged in full, even if they were less than an hour apart from each other.

GetTollFee(DateTime date, Vehicle vehicle) had unnecessary checks for minute being between 0 and 59 inclusive, since it always is. Also I was unsure if there's a bug in the logic during hours 9 through 14, as there is apparently no charge during the first half hour of each of these hours. I left the logic as is.

IsTollFreeVehicle(Vehicle vehicle) checked for each TollFreeVehicles enum member separately, so any changes would have to be applied both in the enum and in the method.

IsTollFreeDate(DateTime date) only checked for holidays in 2013. I created a dummy interface for fetching holidays for any year.